### PR TITLE
Regex changes to match new jetbrains URLs

### DIFF
--- a/jetbrains/AppCode.munki.recipe
+++ b/jetbrains/AppCode.munki.recipe
@@ -45,7 +45,7 @@
           <key>url</key>
           <string>https://data.services.jetbrains.com/products/releases?code=AC</string>
           <key>re_pattern</key>
-          <string>(?P&lt;url&gt;https:\/\/download\.jetbrains\.com\/objc\/AppCode-(\*|\d+(\.\d+){0,2}(\.\*)?)\.dmg)</string>
+          <string>(?P&lt;url&gt;https:\/\/download\.jetbrains\.com\/objc\/AppCode-(\*|\d+(\.\d+){0,2}(.*)?)\.dmg)</string>
         </dict>
       </dict>
       <dict>

--- a/jetbrains/CLion.munki.recipe
+++ b/jetbrains/CLion.munki.recipe
@@ -45,7 +45,7 @@
           <key>url</key>
           <string>https://data.services.jetbrains.com/products/releases?code=CL</string>
           <key>re_pattern</key>
-          <string>(?P&lt;url&gt;https:\/\/download\.jetbrains\.com\/cpp\/CLion-(\*|\d+(\.\d+){0,2}(\.\*)?)\.dmg)</string>
+          <string>(?P&lt;url&gt;https:\/\/download\.jetbrains\.com\/cpp\/CLion-(\*|\d+(\.\d+){0,2}(.*)?)\.dmg)</string>
         </dict>
       </dict>
       <dict>

--- a/jetbrains/Intellij.munki.recipe
+++ b/jetbrains/Intellij.munki.recipe
@@ -45,7 +45,7 @@
           <key>url</key>
           <string>https://data.services.jetbrains.com/products/releases?code=IIU</string>
           <key>re_pattern</key>
-          <string>(?P&lt;url&gt;https:\/\/download\.jetbrains\.com\/idea\/ideaIU-(\*|\d+(\.\d+){0,2}(\.\*)?)\.dmg)</string>
+          <string>(?P&lt;url&gt;https:\/\/download\.jetbrains\.com\/idea\/ideaIU-(\*|\d+(\.\d+){0,2}(.*)?)\.dmg)</string>
         </dict>
       </dict>
       <dict>

--- a/jetbrains/IntellijCE.munki.recipe
+++ b/jetbrains/IntellijCE.munki.recipe
@@ -45,7 +45,7 @@
           <key>url</key>
           <string>https://data.services.jetbrains.com/products/releases?code=IIC</string>
           <key>re_pattern</key>
-          <string>(?P&lt;url&gt;https:\/\/download\.jetbrains\.com\/idea\/ideaIC-(\*|\d+(\.\d+){0,2}(\.\*)?)\.dmg)</string>
+          <string>(?P&lt;url&gt;https:\/\/download\.jetbrains\.com\/idea\/ideaIC-(\*|\d+(\.\d+){0,2}(.*)?)\.dmg)</string>
         </dict>
       </dict>
       <dict>

--- a/jetbrains/PhpStorm.munki.recipe
+++ b/jetbrains/PhpStorm.munki.recipe
@@ -47,7 +47,7 @@
           <key>url</key>
           <string>https://data.services.jetbrains.com/products/releases?code=PS</string>
           <key>re_pattern</key>
-          <string>(?P&lt;url&gt;https:\/\/download\.jetbrains\.com\/webide\/PhpStorm-(\*|\d+(\.\d+){0,2}(\.\*)?)\.dmg)</string>
+          <string>(?P&lt;url&gt;https:\/\/download\.jetbrains\.com\/webide\/PhpStorm-(\*|\d+(\.\d+){0,2}(.*)?)\.dmg)</string>
         </dict>
       </dict>
       <dict>

--- a/jetbrains/PyCharm.munki.recipe
+++ b/jetbrains/PyCharm.munki.recipe
@@ -45,7 +45,7 @@
           <key>url</key>
           <string>https://data.services.jetbrains.com/products/releases?code=PCP</string>
           <key>re_pattern</key>
-          <string>(?P&lt;url&gt;https:\/\/download\.jetbrains\.com\/python\/pycharm-professional-(\*|\d+(\.\d+){0,2}(\.\*)?)\.dmg)</string>
+          <string>(?P&lt;url&gt;https:\/\/download\.jetbrains\.com\/python\/pycharm-professional-(\*|\d+(\.\d+){0,2}(.*)?)\.dmg)</string>
         </dict>
       </dict>
       <dict>

--- a/jetbrains/PyCharmCE.munki.recipe
+++ b/jetbrains/PyCharmCE.munki.recipe
@@ -45,7 +45,7 @@
           <key>url</key>
           <string>https://data.services.jetbrains.com/products/releases?code=PCC</string>
           <key>re_pattern</key>
-          <string>(?P&lt;url&gt;https:\/\/download\.jetbrains\.com\/python\/pycharm-community-(\*|\d+(\.\d+){0,2}(\.\*)?)\.dmg)</string>
+          <string>(?P&lt;url&gt;https:\/\/download\.jetbrains\.com\/python\/pycharm-community-(\*|\d+(\.\d+){0,2}(.*)?)\.dmg)</string>
         </dict>
       </dict>
       <dict>

--- a/jetbrains/RubyMine.munki.recipe
+++ b/jetbrains/RubyMine.munki.recipe
@@ -45,7 +45,7 @@
           <key>url</key>
           <string>https://data.services.jetbrains.com/products/releases?code=RM</string>
           <key>re_pattern</key>
-          <string>(?P&lt;url&gt;https:\/\/download\.jetbrains\.com\/ruby\/RubyMine-(\*|\d+(\.\d+){0,2}(\.\*)?)\.dmg)</string>
+          <string>(?P&lt;url&gt;https:\/\/download\.jetbrains\.com\/ruby\/RubyMine-(\*|\d+(\.\d+){0,2}(.*)?)\.dmg)</string>
         </dict>
       </dict>
       <dict>

--- a/jetbrains/WebStorm.munki.recipe
+++ b/jetbrains/WebStorm.munki.recipe
@@ -45,7 +45,7 @@
           <key>url</key>
           <string>https://data.services.jetbrains.com/products/releases?code=WS</string>
           <key>re_pattern</key>
-          <string>(?P&lt;url&gt;https:\/\/download\.jetbrains\.com\/webstorm\/WebStorm-(\*|\d+(\.\d+){0,2}(\.\*)?)\.dmg)</string>
+          <string>(?P&lt;url&gt;https:\/\/download\.jetbrains\.com\/webstorm\/WebStorm-(\*|\d+(\.\d+){0,2}(.*)?)\.dmg)</string>
         </dict>
       </dict>
       <dict>


### PR DESCRIPTION
Jetbrains is now inserting extra letters into the names of its packages.  These changes relax the regex a bit as to match on these possible additional naming patterns.
